### PR TITLE
fix(IssuerFactory): assign default config email to Issuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.7.2](https://github.com/in2workspace/in2-issuer-api/releases/tag/v1.7.1)
+### Fixed
+- Assign always default config. email to Issuer.
+
 ## [v1.7.1](https://github.com/in2workspace/in2-issuer-api/releases/tag/v1.7.1)
 ### Added
 - Adapt endpoints to oid4vci.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = 'es.in2'
-version = '1.7.1'
+version = '1.7.2'
 
 java {
     sourceCompatibility = '17'

--- a/src/main/java/es/in2/issuer/backend/shared/domain/util/factory/IssuerFactory.java
+++ b/src/main/java/es/in2/issuer/backend/shared/domain/util/factory/IssuerFactory.java
@@ -56,16 +56,13 @@ public class IssuerFactory {
 
                                     return switch (credentialType) {
                                         case LEAR_CREDENTIAL_EMPLOYEE ->
-                                                remoteSignatureServiceImpl.getMandatorMail(procedureId)
-                                                        .flatMap(mail ->
                                                                 remoteSignatureServiceImpl.requestAccessToken(null, SIGNATURE_REMOTE_SCOPE_SERVICE)
                                                                         .flatMap(token ->
                                                                                 remoteSignatureServiceImpl.requestCertificateInfo(token, remoteSignatureConfig.getRemoteSignatureCredentialId())
                                                                         )
                                                                         .flatMap(certInfo ->
-                                                                                remoteSignatureServiceImpl.extractIssuerFromCertificateInfo(certInfo, mail)
-                                                                        )
-                                                        );
+                                                                                remoteSignatureServiceImpl.extractIssuerFromCertificateInfo(certInfo, defaultSignerConfig.getEmail()
+                                                                        ));
 
                                         case VERIFIABLE_CERTIFICATION ->
                                                 remoteSignatureServiceImpl.getMailForVerifiableCertification(procedureId)

--- a/src/test/java/es/in2/issuer/backend/shared/domain/util/factory/IssuerFactoryTest.java
+++ b/src/test/java/es/in2/issuer/backend/shared/domain/util/factory/IssuerFactoryTest.java
@@ -84,22 +84,27 @@ class IssuerFactoryTest {
     void createIssuerRemote_LearCredentialEmployee_SuccessPath() {
         when(remoteSignatureConfig.getRemoteSignatureType()).thenReturn(SIGNATURE_REMOTE_TYPE_CLOUD);
         when(remoteSignatureServiceImpl.validateCredentials()).thenReturn(Mono.just(true));
-        when(remoteSignatureServiceImpl.getMandatorMail(procedureId)).thenReturn(Mono.just("mandator@mail"));
         when(remoteSignatureServiceImpl.requestAccessToken(any(), eq(SIGNATURE_REMOTE_SCOPE_SERVICE)))
                 .thenReturn(Mono.just("token"));
         when(remoteSignatureServiceImpl.requestCertificateInfo("token", "cred-id"))
                 .thenReturn(Mono.just("cert-info"));
+
+        when(defaultSignerConfig.getEmail()).thenReturn("default@issuer.com");
+
         DetailedIssuer expected = DetailedIssuer.builder()
                 .id("id1").organizationIdentifier("org1").organization("o")
                 .country("c").commonName("cn").emailAddress("e").serialNumber("sn")
                 .build();
         when(remoteSignatureConfig.getRemoteSignatureCredentialId()).thenReturn("cred-id");
-        when(remoteSignatureServiceImpl.extractIssuerFromCertificateInfo("cert-info", "mandator@mail"))
+
+        when(remoteSignatureServiceImpl.extractIssuerFromCertificateInfo("cert-info", "default@issuer.com"))
                 .thenReturn(Mono.just(expected));
 
         StepVerifier.create(issuerFactory.createIssuer(procedureId, learType))
                 .expectNext(expected)
                 .verifyComplete();
+
+        verify(defaultSignerConfig).getEmail();
     }
 
     @Test


### PR DESCRIPTION

## [v1.7.2](https://github.com/in2workspace/in2-issuer-api/releases/tag/v1.7.1)
### Fixed
- Assign always default config. email to Issuer.
